### PR TITLE
Add due date for sending SSPS

### DIFF
--- a/src/main/kotlin/no/nav/syfo/varsel/SendSSPSVarselJobb.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/SendSSPSVarselJobb.kt
@@ -70,6 +70,6 @@ class SendSSPSVarselJobb(
     }
 
     private fun LocalDateTime.isDueDatePassed(): Boolean {
-        return this.isEqual( LocalDateTime.now())
+        return this.isEqual(LocalDateTime.now())
     }
 }

--- a/src/main/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAO.kt
@@ -1,0 +1,68 @@
+package no.nav.syfo.varsel.database
+
+import no.nav.syfo.varsel.MerOppfolgingVarselDTO
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
+import org.springframework.stereotype.Repository
+import java.sql.ResultSet
+import java.sql.Timestamp
+import java.time.LocalDateTime
+
+@Repository
+class SendingDueDateDAO(
+    private val namedParameterJdbcTemplate: NamedParameterJdbcTemplate,
+) {
+    fun persistSendingDueDate(merOppfolgingVarselDTO: MerOppfolgingVarselDTO) {
+        val insertStatement = """
+            INSERT INTO SENDING_DUE_DATE (
+                person_ident,
+                utbetaling_id,
+                sykmelding_id,
+                last_day_for_sending
+            ) VALUES (:person_ident, :utbetaling_id, :sykmelding_id, :last_day_for_sending)
+            ON CONFLICT (person_ident, utbetaling_id, sykmelding_id, last_day_for_sending) DO NOTHING 
+            ;
+        """.trimIndent()
+
+        val parameters = MapSqlParameterSource()
+            .addValue("person_ident", merOppfolgingVarselDTO.personIdent)
+            .addValue("utbetaling_id", merOppfolgingVarselDTO.utbetalingId)
+            .addValue("sykmelding_id", merOppfolgingVarselDTO.sykmeldingId)
+            .addValue("last_day_for_sending", Timestamp.valueOf(LocalDateTime.now().plusDays(2)))
+        namedParameterJdbcTemplate.update(insertStatement, parameters)
+    }
+
+    fun getSendingDueDate(
+        personIdent: String,
+        sykmeldingId: String,
+        utbetalingId: String,
+    ): LocalDateTime? {
+        val selectStatement = """
+        SELECT *
+        FROM SENDING_DUE_DATE
+        WHERE person_ident = :person_ident AND sykmelding_id = :sykmelding_id
+        ORDER BY created_at DESC
+        """.trimIndent()
+
+        val parameters = MapSqlParameterSource()
+            .addValue("person_ident", personIdent)
+            .addValue("utbetalingId", utbetalingId)
+            .addValue("sykmeldingId", sykmeldingId)
+
+        return namedParameterJdbcTemplate.query(selectStatement, parameters) { rs, _ -> rs.getDueDate() }.firstOrNull()
+    }
+
+    fun deleteSendingDueDate(sykmeldingId: String) {
+        val deleteStatement = """
+        DELETE FROM SENDING_DUE_DATE
+        WHERE sykmelding_id = :sykmelding_id
+        """.trimIndent()
+
+        val parameters = MapSqlParameterSource()
+            .addValue("sykmelding_id", sykmeldingId)
+
+        namedParameterJdbcTemplate.update(deleteStatement, parameters)
+    }
+
+    fun ResultSet.getDueDate(): LocalDateTime = getTimestamp("last_day_for_sending").toLocalDateTime()
+}

--- a/src/main/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAO.kt
@@ -6,7 +6,9 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 import java.sql.ResultSet
 import java.sql.Timestamp
+import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 @Repository
 class SendingDueDateDAO(
@@ -15,20 +17,23 @@ class SendingDueDateDAO(
     fun persistSendingDueDate(merOppfolgingVarselDTO: MerOppfolgingVarselDTO) {
         val insertStatement = """
             INSERT INTO SENDING_DUE_DATE (
-                person_ident,
-                utbetaling_id,
                 sykmelding_id,
+                utbetaling_id,
+                person_ident,
                 last_day_for_sending
-            ) VALUES (:person_ident, :utbetaling_id, :sykmelding_id, :last_day_for_sending)
-            ON CONFLICT (person_ident, utbetaling_id, sykmelding_id, last_day_for_sending) DO NOTHING 
+            ) VALUES (:sykmelding_id,:utbetaling_id, :person_ident, :last_day_for_sending)
+            ON CONFLICT (person_ident, utbetaling_id, sykmelding_id) DO NOTHING 
             ;
         """.trimIndent()
-
         val parameters = MapSqlParameterSource()
-            .addValue("person_ident", merOppfolgingVarselDTO.personIdent)
-            .addValue("utbetaling_id", merOppfolgingVarselDTO.utbetalingId)
             .addValue("sykmelding_id", merOppfolgingVarselDTO.sykmeldingId)
-            .addValue("last_day_for_sending", Timestamp.valueOf(LocalDateTime.now().plusDays(2)))
+            .addValue("utbetaling_id", merOppfolgingVarselDTO.utbetalingId)
+            .addValue("person_ident", merOppfolgingVarselDTO.personIdent)
+            .addValue(
+                "last_day_for_sending",
+                Timestamp.valueOf(LocalDateTime.of(LocalDate.now(), LocalTime.NOON).plusDays(2))
+            )
+
         namedParameterJdbcTemplate.update(insertStatement, parameters)
     }
 
@@ -41,13 +46,13 @@ class SendingDueDateDAO(
         SELECT *
         FROM SENDING_DUE_DATE
         WHERE person_ident = :person_ident AND sykmelding_id = :sykmelding_id
-        ORDER BY created_at DESC
+        ORDER BY last_day_for_sending DESC
         """.trimIndent()
 
         val parameters = MapSqlParameterSource()
             .addValue("person_ident", personIdent)
-            .addValue("utbetalingId", utbetalingId)
-            .addValue("sykmeldingId", sykmeldingId)
+            .addValue("utbetaling_id", utbetalingId)
+            .addValue("sykmelding_id", sykmeldingId)
 
         return namedParameterJdbcTemplate.query(selectStatement, parameters) { rs, _ -> rs.getDueDate() }.firstOrNull()
     }

--- a/src/main/resources/db/migration/V1_8__Create_table_unsent.sql
+++ b/src/main/resources/db/migration/V1_8__Create_table_unsent.sql
@@ -1,0 +1,8 @@
+CREATE TABLE SENDING_DUE_DATE
+(
+    sykmelding_id        VARCHAR PRIMARY KEY,
+    utbetaling_id        VARCHAR     NOT NULL,
+    person_ident         VARCHAR(11) NOT NULL,
+    last_day_for_sending TIMESTAMP   NOT NULL,
+    UNIQUE (sykmelding_id, utbetaling_id, person_ident)
+);

--- a/src/test/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAOTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/database/SendingDueDateDAOTest.kt
@@ -1,0 +1,94 @@
+package no.nav.syfo.varsel.database
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.syfo.LocalApplication
+import no.nav.syfo.varsel.MerOppfolgingVarselDTO
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.kafka.test.context.EmbeddedKafka
+import java.time.LocalDate
+
+@EmbeddedKafka
+@TestConfiguration
+@SpringBootTest(classes = [LocalApplication::class])
+class SendingDueDateDAOTest : DescribeSpec() {
+    @Autowired
+    private lateinit var sendingDueDateDAO: SendingDueDateDAO
+
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    init {
+        extension(SpringExtension)
+
+        beforeTest {
+            jdbcTemplate.execute("TRUNCATE TABLE SENDING_DUE_DATE CASCADE")
+        }
+
+        val personIdent = "12345678910"
+        val utbetalingId = "123"
+        val sykmeldingId = "321"
+
+        val dto = MerOppfolgingVarselDTO(
+            personIdent,
+            utbetalingId,
+            sykmeldingId,
+        )
+
+        it("Store due date") {
+            sendingDueDateDAO.persistSendingDueDate(dto)
+
+            val dueDate = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+
+            dueDate shouldNotBe null
+            dueDate?.toLocalDate() shouldBe LocalDate.now().plusDays(2)
+        }
+
+        it("Inserting duplicate dto should not cause exception") {
+            sendingDueDateDAO.persistSendingDueDate(dto)
+
+            val dueDate = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+
+            dueDate shouldNotBe null
+            dueDate?.toLocalDate() shouldBe LocalDate.now().plusDays(2)
+        }
+
+        it("Delete record") {
+            sendingDueDateDAO.persistSendingDueDate(dto)
+
+            val dueDate = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+
+            dueDate shouldNotBe null
+            dueDate?.toLocalDate() shouldBe LocalDate.now().plusDays(2)
+
+            sendingDueDateDAO.deleteSendingDueDate(sykmeldingId)
+
+            val dueDateAfterDelete = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            dueDateAfterDelete shouldBe null
+        }
+
+        it("Deleting duplicate dto should not cause exception") {
+            sendingDueDateDAO.persistSendingDueDate(dto)
+
+            val dueDate = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+
+            dueDate shouldNotBe null
+            dueDate?.toLocalDate() shouldBe LocalDate.now().plusDays(2)
+
+            sendingDueDateDAO.deleteSendingDueDate(sykmeldingId)
+            val dueDateAfterDelete = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            dueDateAfterDelete shouldBe null
+            sendingDueDateDAO.deleteSendingDueDate(sykmeldingId)
+            val dueDateAfterDelete2 = sendingDueDateDAO.getSendingDueDate(personIdent, sykmeldingId, utbetalingId)
+            dueDateAfterDelete2 shouldBe null
+        }
+    }
+}


### PR DESCRIPTION
1. Add SENDING_DUE_DATE table, where column `last_day_for_sending` represents last day for trying to send varsel, and the combo `(sykmelding_id, utbetaling_id, person_ident)` is unique.
2. When `SendSSPSVarselJobb` is running succesfully, existing records `SENDING_DUE_DATE` are deleted.
3.  When `SendSSPSVarselJobb` is NOT running succesfully, then `last_day_for_sending`  is persisted (if sending failed for the first time), and function loggs error.
4. Nothing happens if due date is not passed, there will be another try next day.
5. `last_day_for_sending` is set to today + 2 days.

I have made a [kibana alert rule](https://logs.adeo.no/app/management/insightsAndAlerting/triggersActions/rule/4ccc4817-d1a4-4c75-99df-8fa07590cd2d)  for this error message, which should post a message to **esyfo-kibana-alerts** channel.