### PR TITLE
Send more date data on status endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
@@ -18,14 +18,12 @@ import no.nav.syfo.senoppfolging.v2.domain.behovForOppfolging
 import no.nav.syfo.senoppfolging.v2.domain.toQuestionResponse
 import no.nav.syfo.senoppfolging.v2.domain.toResponseStatus
 import no.nav.syfo.syfoopppdfgen.PdfgenService
-import no.nav.syfo.sykepengedagerinformasjon.domain.forelopigBeregnetSluttFormatted
 import no.nav.syfo.sykepengedagerinformasjon.service.SykepengedagerInformasjonService
 import no.nav.syfo.varsel.Varsel
 import no.nav.syfo.varsel.VarselService
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import java.util.*
 
 @Service
@@ -56,8 +54,9 @@ class SenOppfolgingService(
         return SenOppfolgingStatusDTOV2(
             responseStatus = response?.questionResponses?.toResponseStatus() ?: ResponseStatus.NO_RESPONSE,
             response = response?.questionResponses,
-            responseTime = response?.createdAt?.format(DateTimeFormatter.ofPattern("dd.MM.yyyy")),
-            maxDate = sykepengerInformasjon?.forelopigBeregnetSluttFormatted(),
+            svarSubmissionDateTime = response?.createdAt,
+            maxDate = sykepengerInformasjon?.forelopigBeregnetSlutt,
+            utbetaltTomDate = sykepengerInformasjon?.utbetaltTom,
             gjenstaendeSykedager = sykepengerInformasjon?.gjenstaendeSykedager,
             hasAccessToSenOppfolging = hasAccess,
         )

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
@@ -54,7 +54,7 @@ class SenOppfolgingService(
         return SenOppfolgingStatusDTOV2(
             responseStatus = response?.questionResponses?.toResponseStatus() ?: ResponseStatus.NO_RESPONSE,
             response = response?.questionResponses,
-            svarSubmissionDateTime = response?.createdAt,
+            responseDateTime = response?.createdAt,
             maxDate = sykepengerInformasjon?.forelopigBeregnetSlutt,
             utbetaltTomDate = sykepengerInformasjon?.utbetaltTom,
             gjenstaendeSykedager = sykepengerInformasjon?.gjenstaendeSykedager,

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/v2/domain/SenOppfolgingStatusDTOV2.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/v2/domain/SenOppfolgingStatusDTOV2.kt
@@ -1,12 +1,15 @@
 package no.nav.syfo.senoppfolging.v2.domain
 
 import no.nav.syfo.besvarelse.database.domain.QuestionResponse
+import java.time.LocalDate
+import java.time.LocalDateTime
 
 data class SenOppfolgingStatusDTOV2(
     val responseStatus: ResponseStatus,
     val response: List<QuestionResponse>?,
-    val responseTime: String?,
-    val maxDate: String?,
+    val svarSubmissionDateTime: LocalDateTime?,
+    val maxDate: LocalDate?,
+    val utbetaltTomDate: LocalDate?,
     val gjenstaendeSykedager: Int?,
     val hasAccessToSenOppfolging: Boolean,
 )

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/v2/domain/SenOppfolgingStatusDTOV2.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/v2/domain/SenOppfolgingStatusDTOV2.kt
@@ -7,7 +7,7 @@ import java.time.LocalDateTime
 data class SenOppfolgingStatusDTOV2(
     val responseStatus: ResponseStatus,
     val response: List<QuestionResponse>?,
-    val svarSubmissionDateTime: LocalDateTime?,
+    val responseDateTime: LocalDateTime?,
     val maxDate: LocalDate?,
     val utbetaltTomDate: LocalDate?,
     val gjenstaendeSykedager: Int?,


### PR DESCRIPTION
Also send utbetaltTomDate.

And return the dates as LocalDate or LocalDateTime from controller and let framework do the formatting to ISO strings. (Må teste at dette fungerer slik i dev).

These dates are not used yet on frontend. (Frontend is currently getting maxDate and utbetaltTom from SPDI.) So changing the format should not break anything. Next, I plan to update frontend to get maxdate and utbetaltTom from here instead of frontend calling SPDI directly.