### PR TITLE
Send form-steps PDF along with receipt PDF to dokarkiv

### DIFF
--- a/src/main/kotlin/no/nav/syfo/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/DokarkivClient.kt
@@ -44,19 +44,19 @@ class DokarkivClient(
 
     fun postDocumentsForsendelseToDokarkiv(
         fnr: String,
-        documentsData: List<SingleDocumentData>,
         forsendelseTittel: String,
         eksternReferanseId: String,
+        documentsData: List<SingleDocumentData>,
         isForReservedUser: Boolean = false,
     ): DokarkivResponse? {
         return try {
             val token = azureAdClient.getSystemToken(dokarkivScope)
 
             val dokarkivRequest = createDokarkivRequestForDocuments(
-                documentsData,
+                fnr,
                 forsendelseTittel,
                 eksternReferanseId,
-                fnr,
+                documentsData,
                 isForReservedUser
             )
 
@@ -129,21 +129,21 @@ class DokarkivClient(
 
         return postDocumentsForsendelseToDokarkiv(
             fnr,
-            documentsData,
             forsendelseTittel = title,
             eksternReferanseId,
+            documentsData,
             isForReservedUser
         )
     }
 
     private fun createDokarkivRequestForDocuments(
-        documents: List<SingleDocumentData>,
+        fnr: String,
         forsendelseTittel: String,
         eksternReferanseId: String,
-        fnr: String,
+        documentsData: List<SingleDocumentData>,
         isForReservedUser: Boolean,
     ): DokarkivRequest {
-        val dokumenter: List<Dokument> = documents.map {
+        val dokumenter: List<Dokument> = documentsData.map {
             val dokumentvarianter = listOf(Dokumentvariant.create(fysiskDokument = it.pdf, filnavn = it.filnavn))
 
             Dokument.create(
@@ -155,8 +155,8 @@ class DokarkivClient(
         return DokarkivRequest.create(
             avsenderMottaker = AvsenderMottaker.create(fnr),
             dokumenter = dokumenter,
-            eksternReferanseId = forsendelseTittel,
-            tittel = eksternReferanseId,
+            eksternReferanseId = eksternReferanseId,
+            tittel = forsendelseTittel,
             isForReservedUser,
         )
     }

--- a/src/main/kotlin/no/nav/syfo/dokarkiv/DokarkivClient.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/DokarkivClient.kt
@@ -47,7 +47,6 @@ class DokarkivClient(
         forsendelseTittel: String,
         eksternReferanseId: String,
         documentsData: List<SingleDocumentData>,
-        isForReservedUser: Boolean = false,
     ): DokarkivResponse? {
         return try {
             val token = azureAdClient.getSystemToken(dokarkivScope)
@@ -57,7 +56,6 @@ class DokarkivClient(
                 forsendelseTittel,
                 eksternReferanseId,
                 documentsData,
-                isForReservedUser
             )
 
             val response = RestTemplate().postForEntity(
@@ -117,7 +115,6 @@ class DokarkivClient(
         eksternReferanseId: String,
         title: String,
         filnavn: String,
-        isForReservedUser: Boolean = false,
     ): DokarkivResponse? {
         val documentsData = listOf(
             SingleDocumentData(
@@ -132,7 +129,6 @@ class DokarkivClient(
             forsendelseTittel = title,
             eksternReferanseId,
             documentsData,
-            isForReservedUser
         )
     }
 
@@ -141,7 +137,6 @@ class DokarkivClient(
         forsendelseTittel: String,
         eksternReferanseId: String,
         documentsData: List<SingleDocumentData>,
-        isForReservedUser: Boolean,
     ): DokarkivRequest {
         val dokumenter: List<Dokument> = documentsData.map {
             val dokumentvarianter = listOf(Dokumentvariant.create(fysiskDokument = it.pdf, filnavn = it.filnavn))
@@ -157,7 +152,6 @@ class DokarkivClient(
             dokumenter = dokumenter,
             eksternReferanseId = eksternReferanseId,
             tittel = forsendelseTittel,
-            isForReservedUser,
         )
     }
 

--- a/src/main/kotlin/no/nav/syfo/dokarkiv/domain/DokarkivRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/domain/DokarkivRequest.kt
@@ -19,8 +19,9 @@ data class DokarkivRequest(
         fun create(
             avsenderMottaker: AvsenderMottaker,
             dokumenter: List<Dokument>,
-            uuid: String,
+            eksternReferanseId: String,
             tittel: String,
+            isForReservedUser: Boolean,
         ) = DokarkivRequest(
             avsenderMottaker = avsenderMottaker,
             tittel = tittel,
@@ -29,11 +30,11 @@ data class DokarkivRequest(
             journalfoerendeEnhet = JOURNALFORENDE_ENHET,
             journalpostType = "UTGAAENDE",
             tema = "OPP", // Oppfolging
-            kanal = "S",
+            kanal = if (isForReservedUser) "S" else "NAV_NO",
             sak = Sak("GENERELL_SAK"),
             // By default, user can not see documents created by others. Following enables viewing on Mine Saker:
             overstyrInnsynsregler = "VISES_MASKINELT_GODKJENT",
-            eksternReferanseId = uuid,
+            eksternReferanseId = eksternReferanseId,
         )
     }
 }

--- a/src/main/kotlin/no/nav/syfo/dokarkiv/domain/DokarkivRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/domain/DokarkivRequest.kt
@@ -10,7 +10,6 @@ data class DokarkivRequest(
     val journalfoerendeEnhet: Int?,
     val journalpostType: String,
     val tema: String,
-    val kanal: String,
     val sak: Sak,
     val overstyrInnsynsregler: String,
     val eksternReferanseId: String,
@@ -21,7 +20,6 @@ data class DokarkivRequest(
             dokumenter: List<Dokument>,
             eksternReferanseId: String,
             tittel: String,
-            isForReservedUser: Boolean,
         ) = DokarkivRequest(
             avsenderMottaker = avsenderMottaker,
             tittel = tittel,
@@ -30,7 +28,6 @@ data class DokarkivRequest(
             journalfoerendeEnhet = JOURNALFORENDE_ENHET,
             journalpostType = "UTGAAENDE",
             tema = "OPP", // Oppfolging
-            kanal = if (isForReservedUser) "S" else "NAV_NO",
             sak = Sak("GENERELL_SAK"),
             // By default, user can not see documents created by others. Following enables viewing on Mine Saker:
             overstyrInnsynsregler = "VISES_MASKINELT_GODKJENT",

--- a/src/main/kotlin/no/nav/syfo/dokarkiv/domain/Dokumentvariant.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/domain/Dokumentvariant.kt
@@ -9,14 +9,13 @@ data class Dokumentvariant(
     companion object {
         fun create(
             fysiskDokument: ByteArray,
-            uuid: String,
-            filnavnBeforeUUID: String,
+            filnavn: String,
         ): Dokumentvariant {
             return Dokumentvariant(
                 filtype = "PDFA",
                 variantformat = "ARKIV",
                 fysiskDokument = fysiskDokument,
-                filnavn = "$filnavnBeforeUUID-$uuid",
+                filnavn = filnavn,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/dokarkiv/domain/SingleDocumentData.kt
+++ b/src/main/kotlin/no/nav/syfo/dokarkiv/domain/SingleDocumentData.kt
@@ -1,0 +1,5 @@
+data class SingleDocumentData(
+    val pdf: ByteArray,
+    val filnavn: String,
+    val title: String,
+)

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
@@ -134,22 +134,24 @@ class SenOppfolgingService(
             submissionDate
         )
 
-        if (formStepsPdf != null) {
-            documentsData.add(
-                SingleDocumentData(
-                    pdf = formStepsPdf,
-                    filnavn = "SSPS-skjema-utfylling",
-                    title = "Snart slutt på sykepenger - Din utfylling av skjema"
-                )
-            )
-        }
-
+        // On Min side - Dokumenter, the first document in this list will appear as the main document, while others will
+        // appear as attachments for that document
         if (receiptPdf != null) {
             documentsData.add(
                 SingleDocumentData(
                     pdf = receiptPdf,
                     filnavn = "SSPS-kvittering",
-                    title = "Snart slutt på sykepenger - Kvittering på ditt svar",
+                    title = "Spørreskjema ved snart slutt på sykepenger – Kvittering på ditt svar",
+                )
+            )
+        }
+
+        if (formStepsPdf != null) {
+            documentsData.add(
+                SingleDocumentData(
+                    pdf = formStepsPdf,
+                    filnavn = "SSPS-skjema-utfylling",
+                    title = "Spørreskjema ved snart slutt på sykepenger – Din utfylling av skjema"
                 )
             )
         }
@@ -168,7 +170,7 @@ class SenOppfolgingService(
 
             dokarkivClient.postDocumentsForsendelseToDokarkiv(
                 fnr = personident,
-                forsendelseTittel = "SSPS - Utfylling av skjema og kvittering",
+                forsendelseTittel = "Spørreskjema ved snart slutt på sykepenger – Din utfylling og kvittering",
                 eksternReferanseId = storedSubmissionId.toString(),
                 documentsData = documentsData,
             )

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/service/SenOppfolgingService.kt
@@ -168,9 +168,9 @@ class SenOppfolgingService(
 
             dokarkivClient.postDocumentsForsendelseToDokarkiv(
                 fnr = personident,
-                documentsData = documentsData,
                 forsendelseTittel = "SSPS - Utfylling av skjema og kvittering",
                 eksternReferanseId = storedSubmissionId.toString(),
+                documentsData = documentsData,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/syfoopppdfgen/PdfgenRequest.kt
+++ b/src/main/kotlin/no/nav/syfo/syfoopppdfgen/PdfgenRequest.kt
@@ -1,5 +1,8 @@
 package no.nav.syfo.syfoopppdfgen
 
+import no.nav.syfo.senoppfolging.v2.domain.BehovForOppfolgingSvar
+import no.nav.syfo.senoppfolging.v2.domain.FremtidigSituasjonSvar
+
 data class PdfgenRequest(
     val brevdata: Brevdata,
 )
@@ -29,4 +32,9 @@ class BrevdataSenOppfolgingLanding(
     val daysLeft: String?,
     val maxdato: String?,
     val utbetaltTom: String?,
+) : Brevdata
+
+class BrevdataSenOppfolgingFormSteps(
+    val fremtidigSituasjonAnswer: FremtidigSituasjonSvar?,
+    val behovForOppfolgingAnswer: BehovForOppfolgingSvar?,
 ) : Brevdata

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
@@ -68,7 +68,7 @@ class VarselService(
                     fnr = personIdent,
                     pdf = pdf,
                     eksternReferanseId = uuid,
-                    title = "Snart slutt på sykepenger - Informasjon og skjema",
+                    title = "Snart slutt på sykepenger – Informasjon om maksdato og spørreskjema",
                     filnavn = "SSPS-informasjon",
                     isForReservedUser = isUserReservert
                 )

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
@@ -70,7 +70,6 @@ class VarselService(
                     eksternReferanseId = uuid,
                     title = "Snart slutt på sykepenger – Informasjon om maksdato og spørreskjema",
                     filnavn = "SSPS-informasjon",
-                    isForReservedUser = isUserReservert
                 )
             if (dokarkivResponse != null) {
                 val hendelse =

--- a/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
+++ b/src/main/kotlin/no/nav/syfo/varsel/VarselService.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.varsel
 
+import no.nav.syfo.dkif.DkifClient
 import no.nav.syfo.dokarkiv.DokarkivClient
 import no.nav.syfo.logger
 import no.nav.syfo.metric.Metric
@@ -20,6 +21,7 @@ class VarselService(
     private val pdfgenService: PdfgenService,
     private val dokarkivClient: DokarkivClient,
     private val metric: Metric,
+    private val dkifClient: DkifClient,
 ) {
     private val log = logger()
     fun findMerOppfolgingVarselToBeSent(): List<MerOppfolgingVarselDTO> {
@@ -55,17 +57,20 @@ class VarselService(
     @Suppress("MaxLineLength")
     fun sendMerOppfolgingVarsel(merOppfolgingVarselDTO: MerOppfolgingVarselDTO) {
         val personIdent = merOppfolgingVarselDTO.personIdent
+        val isUserReservert = dkifClient.person(personIdent).kanVarsles == false
+
         try {
-            val pdf = pdfgenService.getSenOppfolgingLandingPdf(personIdent)
+            val pdf = pdfgenService.getSenOppfolgingLandingPdf(personIdent, isUserReservert)
             val uuid = UUID.randomUUID().toString()
 
             val dokarkivResponse =
-                dokarkivClient.postDocumentToDokarkiv(
+                dokarkivClient.postSingleDocumentToDokarkiv(
                     fnr = personIdent,
                     pdf = pdf,
-                    uuid = uuid,
-                    "Snart slutt på sykepenger - Informasjon og skjema",
-                    "SSPS-informasjon"
+                    eksternReferanseId = uuid,
+                    title = "Snart slutt på sykepenger - Informasjon og skjema",
+                    filnavn = "SSPS-informasjon",
+                    isForReservedUser = isUserReservert
                 )
             if (dokarkivResponse != null) {
                 val hendelse =

--- a/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
@@ -242,7 +242,7 @@ class SenOppfolgingControllerV2Test :
                         }
                         verify(
                             exactly = 1,
-                        ) { dokarkivClient.postDocumentToDokarkiv(ansattFnr, any(), any(), any(), any()) }
+                        ) { dokarkivClient.postSingleDocumentToDokarkiv(ansattFnr, any(), any(), any(), any()) }
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
@@ -242,7 +242,7 @@ class SenOppfolgingControllerV2Test :
                         }
                         verify(
                             exactly = 1,
-                        ) { dokarkivClient.postSingleDocumentToDokarkiv(ansattFnr, any(), any(), any(), any()) }
+                        ) { dokarkivClient.postDocumentsForsendelseToDokarkiv(ansattFnr, any(), any(), any()) }
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
@@ -169,7 +169,7 @@ class VarselServiceTest : DescribeSpec() {
             }
 
             it("Should not store utsendt varsel if pdfgen fails") {
-                every { pdfgenService.getSenOppfolgingLandingPdf(any()) } throws Exception("Help me")
+                every { pdfgenService.getSenOppfolgingLandingPdf(any(), any()) } throws Exception("Help me")
 
                 varselService.sendMerOppfolgingVarsel(
                     MerOppfolgingVarselDTO(
@@ -185,9 +185,9 @@ class VarselServiceTest : DescribeSpec() {
             }
 
             it("Should not store utsendt varsel journalforing fails") {
-                every { pdfgenService.getSenOppfolgingLandingPdf(any()) } returns ByteArray(1)
+                every { pdfgenService.getSenOppfolgingLandingPdf(any(), any()) } returns ByteArray(1)
                 every {
-                    dokarkivClient.postDocumentToDokarkiv(any(), any(), any(), any(), any())
+                    dokarkivClient.postSingleDocumentToDokarkiv(any(), any(), any(), any(), any())
                 } throws Exception("Help me")
 
                 varselService.sendMerOppfolgingVarsel(
@@ -204,9 +204,9 @@ class VarselServiceTest : DescribeSpec() {
             }
 
             it("Should store utsendt varsel post to dokarkiv OK") {
-                every { pdfgenService.getSenOppfolgingLandingPdf(any()) } returns ByteArray(1)
+                every { pdfgenService.getSenOppfolgingLandingPdf(any(), any()) } returns ByteArray(1)
                 every {
-                    dokarkivClient.postDocumentToDokarkiv(any(), any(), any(), any(), any())
+                    dokarkivClient.postSingleDocumentToDokarkiv(any(), any(), any(), any(), any())
                 } returns DokarkivResponse(null, 1, null, "status", null)
 
                 varselService.sendMerOppfolgingVarsel(

--- a/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
@@ -14,6 +14,7 @@ import io.mockk.verify
 import no.nav.syfo.LocalApplication
 import no.nav.syfo.behandlendeenhet.BehandlendeEnhetClient
 import no.nav.syfo.behandlendeenhet.domain.BehandlendeEnhet
+import no.nav.syfo.dkif.DkifClient
 import no.nav.syfo.dokarkiv.DokarkivClient
 import no.nav.syfo.dokarkiv.domain.DokarkivResponse
 import no.nav.syfo.pdl.PdlClient
@@ -47,6 +48,9 @@ class VarselServiceTest : DescribeSpec() {
     @MockkBean(relaxed = true)
     lateinit var behandlendeEnhetClient: BehandlendeEnhetClient
 
+    @MockkBean(relaxed = true)
+    lateinit var dkifClient: DkifClient
+
     @Autowired
     lateinit var varselService: VarselService
 
@@ -76,6 +80,8 @@ class VarselServiceTest : DescribeSpec() {
 
         describe("VarselService") {
             it("Should store utsendt varsel") {
+                every { dkifClient.person(any()).kanVarsles } returns true
+
                 varselService.sendMerOppfolgingVarsel(
                     MerOppfolgingVarselDTO(
                         personIdent = "12345678910",

--- a/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/varsel/VarselServiceTest.kt
@@ -191,6 +191,7 @@ class VarselServiceTest : DescribeSpec() {
             }
 
             it("Should not store utsendt varsel journalforing fails") {
+                every { dkifClient.person(any()).kanVarsles } returns true
                 every { pdfgenService.getSenOppfolgingLandingPdf(any(), any()) } returns ByteArray(1)
                 every {
                     dokarkivClient.postSingleDocumentToDokarkiv(any(), any(), any(), any(), any())


### PR DESCRIPTION
Send the two PDFs in one dokarkiv forsendelse.

Catch and handle exceptions from pdfgenClient so that control flow in any case will continue in handleSubmitForm.

Assign correct kanal in calls to dokarkiv, depending on whether isUserReservert.

Refactor PdfgenClient somewhat for less duplicate code.