### PR TITLE
Enforce fixed order for question responses when retreiving status

### DIFF
--- a/src/main/kotlin/no/nav/syfo/besvarelse/database/ResponseDao.kt
+++ b/src/main/kotlin/no/nav/syfo/besvarelse/database/ResponseDao.kt
@@ -3,6 +3,7 @@ package no.nav.syfo.besvarelse.database
 import no.nav.syfo.besvarelse.database.domain.FormResponse
 import no.nav.syfo.besvarelse.database.domain.FormType
 import no.nav.syfo.besvarelse.database.domain.QuestionResponse
+import no.nav.syfo.besvarelse.database.domain.arrangeQuestionResponsesInFixedOrder
 import no.nav.syfo.domain.PersonIdentNumber
 import org.springframework.dao.EmptyResultDataAccessException
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource
@@ -162,7 +163,7 @@ class ResponseDao(
                 .addValue("form_type", formType.name)
                 .addValue("from_date", Date.valueOf(from))
 
-        return executeFormResponseQuery(query, namedParameters)?.firstOrNull()
+        return executeFormResponseQueryAndOrderQuestionResponses(query, namedParameters)?.firstOrNull()
     }
 
     fun findLatestFormResponse(
@@ -193,7 +194,7 @@ class ResponseDao(
                 .addValue("person_ident", personIdent.value)
                 .addValue("form_type", formType.name)
 
-        return executeFormResponseQuery(query, namedParameters)?.firstOrNull()
+        return executeFormResponseQueryAndOrderQuestionResponses(query, namedParameters)?.firstOrNull()
     }
 
     fun findResponseByVarselId(varselId: UUID): FormResponse? {
@@ -219,11 +220,11 @@ class ResponseDao(
             MapSqlParameterSource()
                 .addValue("varsel_id", varselId)
 
-        return executeFormResponseQuery(query, namedParameters)?.firstOrNull()
+        return executeFormResponseQueryAndOrderQuestionResponses(query, namedParameters)?.firstOrNull()
     }
 
     @Suppress("SwallowedException")
-    private fun executeFormResponseQuery(
+    private fun executeFormResponseQueryAndOrderQuestionResponses(
         query: String,
         namedParameters: SqlParameterSource,
     ): List<FormResponse>? =
@@ -232,7 +233,7 @@ class ResponseDao(
                 query,
                 namedParameters,
                 FormResponseResultSetExtractor(),
-            )
+            )?.map { it.arrangeQuestionResponsesInFixedOrder() }
         } catch (e: EmptyResultDataAccessException) {
             null
         }

--- a/src/main/kotlin/no/nav/syfo/besvarelse/database/domain/FormResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/besvarelse/database/domain/FormResponse.kt
@@ -12,3 +12,8 @@ data class FormResponse(
     val utsendtVarselUUID: UUID? = null,
     val questionResponses: MutableList<QuestionResponse> = mutableListOf(),
 )
+
+fun FormResponse.arrangeQuestionResponsesInFixedOrder(): FormResponse {
+    val sortedQuestionResponses = this.questionResponses.toFixedOrder()
+    return this.copy(questionResponses = sortedQuestionResponses.toMutableList())
+}

--- a/src/main/kotlin/no/nav/syfo/besvarelse/database/domain/QuestionResponse.kt
+++ b/src/main/kotlin/no/nav/syfo/besvarelse/database/domain/QuestionResponse.kt
@@ -6,3 +6,23 @@ data class QuestionResponse(
     val answerType: String,
     val answerText: String,
 )
+
+fun List<QuestionResponse>.toFixedOrder(): List<QuestionResponse> {
+    val questionResponsesInFixedOrder = mutableListOf<QuestionResponse>()
+
+    this.find { it.questionType == "FREMTIDIG_SITUASJON" }?.let {
+        questionResponsesInFixedOrder.add(it)
+    }
+
+    this.find { it.questionType == "BEHOV_FOR_OPPFOLGING" }?.let {
+        questionResponsesInFixedOrder.add(it)
+    }
+
+    this.filterNot {
+        it.questionType == "FREMTIDIG_SITUASJON" || it.questionType == "BEHOV_FOR_OPPFOLGING"
+    }.let {
+        questionResponsesInFixedOrder.addAll(it)
+    }
+
+    return questionResponsesInFixedOrder
+}

--- a/src/test/kotlin/no/nav/syfo/besvarelse/database/domain/FormResponseTest.kt
+++ b/src/test/kotlin/no/nav/syfo/besvarelse/database/domain/FormResponseTest.kt
@@ -1,0 +1,37 @@
+package no.nav.syfo.besvarelse.database.domain
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import no.nav.syfo.domain.PersonIdentNumber
+import java.time.LocalDateTime
+import java.util.UUID
+
+class FormResponseTest : StringSpec({
+    "should arrange question responses in fixed order" {
+        val questionResponse2 = QuestionResponse(
+            "BEHOV_FOR_OPPFOLGING",
+            "Ønsker du å be om oppfølging?",
+            "JA",
+            "Ja, jeg ønsker å be om oppfølging"
+        )
+
+        val questionResponse1 = QuestionResponse(
+            "FREMTIDIG_SITUASJON",
+            "Hvilken situasjon tror du at du er i når sykepengene har tatt slutt?",
+            "FORTSATT_SYK",
+            "Jeg er for syk til å jobbe"
+        )
+
+        val formResponse = FormResponse(
+            uuid = UUID.randomUUID(),
+            personIdent = PersonIdentNumber("12345678911"),
+            createdAt = LocalDateTime.now(),
+            formType = FormType.SEN_OPPFOLGING_V2,
+            questionResponses = mutableListOf(questionResponse2, questionResponse1)
+        )
+
+        val arrangedFormResponse = formResponse.arrangeQuestionResponsesInFixedOrder()
+
+        arrangedFormResponse.questionResponses shouldBe listOf(questionResponse1, questionResponse2)
+    }
+})


### PR DESCRIPTION
Frontend kaster zod valideringsfeil når den henter status og questionReponses-listen kommer i "feil" rekkefølge, altså når QuestionResponse med questionType "BEHOV_FOR_OPPFØLGING" kommer før QuestionResponse med questionType "FREMTIDIG_SITUASJON". Dette kan skje siden vi ikke tvinger en bestemt rekkefølge når disse lagres som to rader i en tabell. 

Denne PR sørger for at de blir returnert i den "riktige" rekkefølgen fra ResponseDAO.

Bør testes litt i dev.