### PR TITLE
add veileder endpoint for fetching responses to kartleggingssporsmal

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalVeilederControllerV1.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalVeilederControllerV1.kt
@@ -1,0 +1,48 @@
+package no.nav.syfo.kartlegging
+
+import no.nav.security.token.support.core.api.ProtectedWithClaims
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.syfo.auth.NoAccess
+import no.nav.syfo.auth.TokenUtil
+import no.nav.syfo.auth.TokenUtil.TokenIssuer.AZUREAD
+import no.nav.syfo.domain.PersonIdentNumber
+import no.nav.syfo.kartlegging.domain.PersistedKartleggingssporsmal
+import no.nav.syfo.kartlegging.exception.UserResponseNotFoundException
+import no.nav.syfo.kartlegging.service.KartleggingssporsmalService
+import no.nav.syfo.veiledertilgang.VeilederTilgangClient
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.util.UUID
+
+@RestController
+@ProtectedWithClaims(issuer = AZUREAD)
+@RequestMapping("/api/v1/internad/kartleggingssporsmal")
+class KartleggingssporsmalVeilederControllerV1(
+    val tokenValidationContextHolder: TokenValidationContextHolder,
+    val veilederTilgangClient: VeilederTilgangClient,
+    val kartleggingssporsmalService: KartleggingssporsmalService
+) {
+
+    @GetMapping("/{uuid}", produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun getKartleggingssporsmal(@PathVariable uuid: UUID): ResponseEntity<PersistedKartleggingssporsmal?> {
+        val token = TokenUtil.getIssuerToken(tokenValidationContextHolder, AZUREAD)
+
+        val response = kartleggingssporsmalService.getKartleggingssporsmalByUuid(uuid)
+            ?: throw UserResponseNotFoundException("Fant ikke kartleggingsspørsmål med uuid: $uuid")
+
+        val hasVeilederTilgangToPerson = veilederTilgangClient.hasVeilederTilgangToPerson(
+            token = token,
+            personident = PersonIdentNumber(response.fnr),
+        )
+        if (!hasVeilederTilgangToPerson) {
+            throw NoAccess("Veileder har ikke tilgang til person")
+        }
+        return ResponseEntity
+            .ok(response)
+    }
+
+}

--- a/src/main/kotlin/no/nav/syfo/kartlegging/database/KartleggingssporsmalDAO.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/database/KartleggingssporsmalDAO.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.kartlegging.domain.formsnapshot.toJsonString
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate
 import org.springframework.stereotype.Repository
 import java.sql.ResultSet
+import java.util.UUID
 
 @Repository
 class KartleggingssporsmalDAO(
@@ -16,21 +17,22 @@ class KartleggingssporsmalDAO(
 
     fun persistKartleggingssporsmal(
         kartleggingssporsmal: Kartleggingssporsmal,
-    ) {
+    ): UUID {
         val insertStatement = """
-            INSERT INTO KARTLEGGINGSPORSMAL (
-                fnr,
-                form_snapshot,
-                created_at
-            ) VALUES (:fnr, :form_snapshot::jsonb, NOW());
-        """.trimIndent()
+        INSERT INTO KARTLEGGINGSPORSMAL (
+            fnr,
+            form_snapshot,
+            created_at
+        ) VALUES (:fnr, :form_snapshot::jsonb, NOW())
+        RETURNING uuid;
+    """.trimIndent()
 
         val parameters = mapOf(
             "fnr" to kartleggingssporsmal.fnr,
             "form_snapshot" to kartleggingssporsmal.formSnapshot.toJsonString(),
         )
-
-        namedParameterJdbcTemplate.update(insertStatement, parameters)
+        return namedParameterJdbcTemplate.queryForObject(insertStatement, parameters, UUID::class.java)
+            ?: throw IllegalStateException("Failed to persist kartleggingssporsmal (no uuid returned)")
     }
 
     fun getLatestKartleggingssporsmalByFnr(fnr: String): PersistedKartleggingssporsmal? {
@@ -51,8 +53,25 @@ class KartleggingssporsmalDAO(
             .firstOrNull()
     }
 
+    fun getKartleggingssporsmalByUuid(uuid: UUID): PersistedKartleggingssporsmal? {
+        val selectStatement = """
+            SELECT
+                uuid,
+                fnr,
+                form_snapshot,
+                created_at
+            FROM KARTLEGGINGSPORSMAL
+            WHERE uuid = :uuid;
+        """.trimIndent()
+
+        val parameters = mapOf("uuid" to uuid)
+
+        return namedParameterJdbcTemplate.query(selectStatement, parameters) { rs, _ -> rs.toKartleggingssporsmal() }
+            .firstOrNull()
+    }
+
     fun ResultSet.toKartleggingssporsmal(): PersistedKartleggingssporsmal = PersistedKartleggingssporsmal(
-        uuid = getObject("uuid", java.util.UUID::class.java),
+        uuid = getObject("uuid", UUID::class.java),
         fnr = getString("fnr"),
         formSnapshot = getString("form_snapshot").let { FormSnapshot.jsonToFormSnapshot(it) },
         createdAt = getTimestamp("created_at").toInstant()

--- a/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.kartlegging.domain.formsnapshot.logger
 import no.nav.syfo.kartlegging.domain.formsnapshot.validateFields
 import no.nav.syfo.kartlegging.exception.InvalidFormException
 import org.springframework.stereotype.Service
+import java.util.UUID
 
 @Service
 class KartleggingssporsmalService(
@@ -29,6 +30,11 @@ class KartleggingssporsmalService(
             )
         )
     }
+
+    fun getKartleggingssporsmalByUuid(uuid: UUID): PersistedKartleggingssporsmal? {
+        return kartleggingssporsmalDAO.getKartleggingssporsmalByUuid(uuid)
+    }
+
     fun validateFormSnapshot(formSnapshot: FormSnapshot) {
         val requiredFieldIds = listOf(
             "hvorSannsynligTilbakeTilJobben" to FormSnapshotFieldType.RADIO_GROUP,

--- a/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalVeilederControllerV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalVeilederControllerV1Test.kt
@@ -1,0 +1,141 @@
+package no.nav.syfo.kartlegging
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.syfo.auth.NoAccess
+import no.nav.syfo.kartlegging.domain.PersistedKartleggingssporsmal
+import no.nav.syfo.kartlegging.domain.formsnapshot.FormSnapshot
+import no.nav.syfo.kartlegging.domain.formsnapshot.FormSnapshotFieldOption
+import no.nav.syfo.kartlegging.domain.formsnapshot.RadioGroupFieldSnapshot
+import no.nav.syfo.kartlegging.exception.UserResponseNotFoundException
+import no.nav.syfo.kartlegging.service.KartleggingssporsmalService
+import no.nav.syfo.veiledertilgang.VeilederTilgangClient
+import org.springframework.http.HttpStatusCode
+import java.time.Instant
+import java.util.UUID
+
+class KartleggingssporsmalVeilederControllerV1Test : DescribeSpec({
+    val tokenValidationContextHolder = mockk<TokenValidationContextHolder>(relaxed = true)
+    val veilederTilgangClient = mockk<VeilederTilgangClient>(relaxed = true)
+    val kartleggingssporsmalService = mockk<KartleggingssporsmalService>(relaxed = true)
+
+    val controller = KartleggingssporsmalVeilederControllerV1(
+        tokenValidationContextHolder = tokenValidationContextHolder,
+        veilederTilgangClient = veilederTilgangClient,
+        kartleggingssporsmalService = kartleggingssporsmalService
+    )
+
+    beforeTest { clearAllMocks() }
+
+    describe("GET /api/v1/internad/kartleggingssporsmal/{uuid}") {
+        it("returns 200 OK with persisted kartleggingssporsmal when veileder has access") {
+            val uuid = UUID.randomUUID()
+            val fnr = "12345678910"
+            val formSnapshot = FormSnapshot(
+                formIdentifier = "kartlegging-test-form",
+                formSemanticVersion = "1.0.0",
+                formSnapshotVersion = "1",
+                fieldSnapshots = listOf(
+                    RadioGroupFieldSnapshot(
+                        fieldId = "hvorSannsynligTilbakeTilJobben",
+                        label = "Label 1",
+                        options = listOf(
+                            FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                            FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                        ),
+                    ),
+                    RadioGroupFieldSnapshot(
+                        fieldId = "samarbeidOgRelasjonTilArbeidsgiver",
+                        label = "Label 2",
+                        options = listOf(
+                            FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                            FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                        ),
+                    ),
+                    RadioGroupFieldSnapshot(
+                        fieldId = "naarTilbakeTilJobben",
+                        label = "Label 3",
+                        options = listOf(
+                            FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                            FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                        ),
+                    ),
+                ),
+            )
+            val persisted = PersistedKartleggingssporsmal(
+                uuid = uuid,
+                fnr = fnr,
+                formSnapshot = formSnapshot,
+                createdAt = Instant.now(),
+            )
+
+            every { kartleggingssporsmalService.getKartleggingssporsmalByUuid(uuid) } returns persisted
+            every { veilederTilgangClient.hasVeilederTilgangToPerson(any(), any()) } returns true
+
+            val response = controller.getKartleggingssporsmal(uuid)
+
+            response.statusCode.isSameCodeAs(HttpStatusCode.valueOf(200)) shouldBe true
+            val body = response.body!!
+            body.uuid shouldBe uuid
+            body.fnr shouldBe fnr
+            body.formSnapshot shouldBe formSnapshot
+        }
+
+        it("throws UserResponseNotFoundException when uuid not found") {
+            val uuid = UUID.randomUUID()
+            every { kartleggingssporsmalService.getKartleggingssporsmalByUuid(uuid) } returns null
+
+            shouldThrow<UserResponseNotFoundException> { controller.getKartleggingssporsmal(uuid) }
+        }
+
+        it("throws NoAccess when veileder does not have access") {
+            val uuid = UUID.randomUUID()
+            val fnr = "12345678910"
+            val persisted = PersistedKartleggingssporsmal(
+                uuid = uuid,
+                fnr = fnr,
+                formSnapshot = FormSnapshot(
+                    formIdentifier = "kartlegging-test-form",
+                    formSemanticVersion = "1.0.0",
+                    formSnapshotVersion = "1",
+                    fieldSnapshots = listOf(
+                        RadioGroupFieldSnapshot(
+                            fieldId = "hvorSannsynligTilbakeTilJobben",
+                            label = "Label 1",
+                            options = listOf(
+                                FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                                FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                            ),
+                        ),
+                        RadioGroupFieldSnapshot(
+                            fieldId = "samarbeidOgRelasjonTilArbeidsgiver",
+                            label = "Label 2",
+                            options = listOf(
+                                FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                                FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                            ),
+                        ),
+                        RadioGroupFieldSnapshot(
+                            fieldId = "naarTilbakeTilJobben",
+                            label = "Label 3",
+                            options = listOf(
+                                FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
+                                FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
+                            ),
+                        ),
+                    ),
+                ),
+                createdAt = Instant.now(),
+            )
+            every { kartleggingssporsmalService.getKartleggingssporsmalByUuid(uuid) } returns persisted
+            every { veilederTilgangClient.hasVeilederTilgangToPerson(any(), any()) } returns false
+
+            shouldThrow<NoAccess> { controller.getKartleggingssporsmal(uuid) }
+        }
+    }
+})

--- a/src/test/kotlin/no/nav/syfo/kartlegging/database/KartleggingssporsmalDAOTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/database/KartleggingssporsmalDAOTest.kt
@@ -87,5 +87,62 @@ class KartleggingssporsmalDAOTest : DescribeSpec() {
                 persisted.createdAt shouldNotBe null
             }
         }
+        describe("KartleggingssporsmalDAO.getKartleggingssporsmalByUuid") {
+            it("gets persisted kartleggingssporsmal by uuid") {
+                val fnr = "12345678910"
+                val snapshot = FormSnapshot(
+                    formIdentifier = "kartlegging_skjematype",
+                    formSemanticVersion = "1.0.0",
+                    formSnapshotVersion = "1",
+                    fieldSnapshots = listOf(
+                        TextFieldSnapshot(
+                            fieldId = "tekst1",
+                            label = "Hva er svaret?",
+                            value = "Dette er et svar"
+                        ),
+                        SingleCheckboxFieldSnapshot(
+                            fieldId = "enkel_checkbox",
+                            label = "Har du lest og forstått?",
+                            value = true
+                        ),
+                        CheckboxFieldSnapshot(
+                            fieldId = "flervalg",
+                            label = "Velg det som gjelder",
+                            options = listOf(
+                                FormSnapshotFieldOption("opt1", "Alternativ 1", wasSelected = true),
+                                FormSnapshotFieldOption("opt2", "Alternativ 2", wasSelected = false)
+                            )
+                        ),
+                        RadioGroupFieldSnapshot(
+                            fieldId = "radio",
+                            label = "Velg ett",
+                            options = listOf(
+                                FormSnapshotFieldOption("r1", "R1", wasSelected = false),
+                                FormSnapshotFieldOption("r2", "R2", wasSelected = true)
+                            )
+                        )
+                    ),
+                    sections = listOf(
+                        FormSection(
+                            sectionId = "seksjon1",
+                            sectionTitle = "Seksjon 1"
+                        )
+                    )
+                )
+
+                val uuid = kartleggingssporsmalDAO.persistKartleggingssporsmal(
+                    Kartleggingssporsmal(
+                        fnr = fnr,
+                        formSnapshot = snapshot
+                    )
+                )
+
+                val persisted = kartleggingssporsmalDAO.getKartleggingssporsmalByUuid(uuid)
+                persisted!!.fnr shouldBe fnr
+                persisted.formSnapshot shouldBe snapshot
+                persisted.uuid shouldNotBe null
+                persisted.createdAt shouldNotBe null
+            }
+        }
     }
 }


### PR DESCRIPTION
Planen er at isyfo vil motta en melding over kafka når vi har mottat et svar fra bruker. Meldingen vil inneholde uuid for svaret, og syfomodiaperson kan da gjøre oppslag mot oss med denne id'en.