### PR TITLE
IS-3829: Vis skjemavariant via api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
@@ -8,6 +8,7 @@ import no.nav.syfo.auth.getFnr
 import no.nav.syfo.kartlegging.domain.KandidatStatusResponse
 import no.nav.syfo.kartlegging.domain.KartleggingssporsmalRequest
 import no.nav.syfo.kartlegging.domain.PersistedKartleggingssporsmal
+import no.nav.syfo.kartlegging.exception.KandidatNotFoundException
 import no.nav.syfo.kartlegging.exception.NotKandidatException
 import no.nav.syfo.kartlegging.service.KandidatService
 import no.nav.syfo.kartlegging.service.KartleggingssporsmalService
@@ -72,12 +73,15 @@ class KartleggingssporsmalControllerV1(
         val personIdent = tokenValidator.validateTokenXClaims().getFnr()
 
         val muligKandidat = kandidatService.getKandidatByFnr(personIdent)
-        if (muligKandidat?.isKandidat() != true) {
+            ?: throw KandidatNotFoundException("Fant ikke kandidat")
+
+        if (!muligKandidat.isKandidat()) {
             return ResponseEntity
                 .ok()
                 .body(
                     KandidatStatusResponse(
                         isKandidat = false,
+                        skjemavariant = muligKandidat.skjemavariant,
                         formResponse = null,
                     ),
                 )
@@ -90,6 +94,7 @@ class KartleggingssporsmalControllerV1(
             .body(
                 KandidatStatusResponse(
                     isKandidat = true,
+                    skjemavariant = muligKandidat.skjemavariant,
                     formResponse = latest,
                 ),
             )

--- a/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
@@ -73,15 +73,14 @@ class KartleggingssporsmalControllerV1(
         val personIdent = tokenValidator.validateTokenXClaims().getFnr()
 
         val muligKandidat = kandidatService.getKandidatByFnr(personIdent)
-            ?: throw KandidatNotFoundException("Fant ikke kandidat")
 
-        if (!muligKandidat.isKandidat()) {
+        if (muligKandidat?.isKandidat() != true) {
             return ResponseEntity
                 .ok()
                 .body(
                     KandidatStatusResponse(
                         isKandidat = false,
-                        skjemavariant = muligKandidat.skjemavariant,
+                        skjemavariant = null,
                         formResponse = null,
                     ),
                 )

--- a/src/main/kotlin/no/nav/syfo/kartlegging/domain/Kartleggingssporsmal.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/domain/Kartleggingssporsmal.kt
@@ -22,6 +22,6 @@ data class PersistedKartleggingssporsmal(
 
 data class KandidatStatusResponse(
     val isKandidat: Boolean,
-    val skjemavariant: String,
+    val skjemavariant: String?,
     val formResponse: PersistedKartleggingssporsmal?
 )

--- a/src/main/kotlin/no/nav/syfo/kartlegging/domain/Kartleggingssporsmal.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/domain/Kartleggingssporsmal.kt
@@ -20,4 +20,8 @@ data class PersistedKartleggingssporsmal(
     formSnapshot = formSnapshot,
 )
 
-data class KandidatStatusResponse(val isKandidat: Boolean, val formResponse: PersistedKartleggingssporsmal?)
+data class KandidatStatusResponse(
+    val isKandidat: Boolean,
+    val skjemavariant: String,
+    val formResponse: PersistedKartleggingssporsmal?
+)

--- a/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1WebMvcTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1WebMvcTest.kt
@@ -213,18 +213,6 @@ class KartleggingssporsmalControllerV1WebMvcTest : DescribeSpec() {
                 }
             }
 
-            it("returns 404 when kandidat not found") {
-                every { kandidatService.getKandidatByFnr(fnr) } returns null
-
-                mockMvc.get("/api/v1/kartleggingssporsmal/kandidat-status") {
-                    header(HttpHeaders.AUTHORIZATION, "Bearer ${bearerToken()}")
-                }.andExpect {
-                    status { isNotFound() }
-                    content { contentType(MediaType.APPLICATION_JSON) }
-                    jsonPath("$.reason") { value("Fant ikke kandidat") }
-                }
-            }
-
             it("returns isKandidat false with null formResponse when kandidat is IKKE_KANDIDAT") {
                 every { kandidatService.getKandidatByFnr(fnr) } returns KartleggingssporsmalKandidat(
                     kandidatId = kandidatId,
@@ -241,7 +229,7 @@ class KartleggingssporsmalControllerV1WebMvcTest : DescribeSpec() {
                     content { contentType(MediaType.APPLICATION_JSON) }
                     jsonPath("$.isKandidat") { value(false) }
                     jsonPath("$.formResponse") { value(null as Any?) }
-                    jsonPath("$.skjemavariant") { value("FLERVALG_V1") }
+                    jsonPath("$.skjemavariant") { value(null as Any?) }
                 }
             }
         }

--- a/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1WebMvcTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1WebMvcTest.kt
@@ -208,12 +208,31 @@ class KartleggingssporsmalControllerV1WebMvcTest : DescribeSpec() {
                     status { isOk() }
                     content { contentType(MediaType.APPLICATION_JSON) }
                     jsonPath("$.isKandidat") { value(true) }
+                    jsonPath("$.skjemavariant") { value("FLERVALG_V1") }
                     assertPersistedKartleggingssporsmalJson("$.formResponse", uuid)
                 }
             }
 
-            it("returns isKandidat false with null formResponse when not kandidat") {
+            it("returns 404 when kandidat not found") {
                 every { kandidatService.getKandidatByFnr(fnr) } returns null
+
+                mockMvc.get("/api/v1/kartleggingssporsmal/kandidat-status") {
+                    header(HttpHeaders.AUTHORIZATION, "Bearer ${bearerToken()}")
+                }.andExpect {
+                    status { isNotFound() }
+                    content { contentType(MediaType.APPLICATION_JSON) }
+                    jsonPath("$.reason") { value("Fant ikke kandidat") }
+                }
+            }
+
+            it("returns isKandidat false with null formResponse when kandidat is IKKE_KANDIDAT") {
+                every { kandidatService.getKandidatByFnr(fnr) } returns KartleggingssporsmalKandidat(
+                    kandidatId = kandidatId,
+                    personIdent = fnr,
+                    status = KandidatStatus.IKKE_KANDIDAT,
+                    skjemavariant = "FLERVALG_V1",
+                    createdAt = Instant.now(),
+                )
 
                 mockMvc.get("/api/v1/kartleggingssporsmal/kandidat-status") {
                     header(HttpHeaders.AUTHORIZATION, "Bearer ${bearerToken()}")
@@ -222,6 +241,7 @@ class KartleggingssporsmalControllerV1WebMvcTest : DescribeSpec() {
                     content { contentType(MediaType.APPLICATION_JSON) }
                     jsonPath("$.isKandidat") { value(false) }
                     jsonPath("$.formResponse") { value(null as Any?) }
+                    jsonPath("$.skjemavariant") { value("FLERVALG_V1") }
                 }
             }
         }


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

Eksponerer `skjemavariant` via api for kandidat status

## Endringer

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)
