### PR TITLE
remove fieldId validation kartleggingssporsmal

### DIFF
--- a/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
@@ -58,24 +58,7 @@ class KartleggingssporsmalService(
         kartleggingssporsmalDAO.getKartleggingssporsmalByUuid(uuid)
 
     fun validateFormSnapshot(formSnapshot: FormSnapshot) {
-        val requiredFieldIds = listOf(
-            "hvorSannsynligTilbakeTilJobben" to FormSnapshotFieldType.RADIO_GROUP,
-            "samarbeidOgRelasjonTilArbeidsgiver" to FormSnapshotFieldType.RADIO_GROUP,
-            "naarTilbakeTilJobben" to FormSnapshotFieldType.RADIO_GROUP,
-        )
-
         try {
-            for ((requiredFieldId, requiredFieldType) in requiredFieldIds) {
-                val fieldSnapshot: FieldSnapshot? = formSnapshot.fieldSnapshots.find { it.fieldId == requiredFieldId }
-                if (fieldSnapshot == null) {
-                    throw IllegalArgumentException("Missing required field with id: $requiredFieldId")
-                }
-                if (fieldSnapshot.fieldType != requiredFieldType) {
-                    throw IllegalArgumentException(
-                        "Field with id: $requiredFieldId has incorrect type. Expected: $requiredFieldType, Found: ${fieldSnapshot.fieldType}"
-                    )
-                }
-            }
             formSnapshot.validateFields()
         } catch (e: Exception) {
             logger.warn("Invalid form in request body: ${e.message}")

--- a/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1Test.kt
@@ -124,39 +124,6 @@ class KartleggingssporsmalControllerV1Test :
                 persistedSlot.captured.fnr shouldBe fnr
                 persistedSlot.captured.formSnapshot shouldBe formSnapshot
             }
-
-            it("returns 400 InvalidFormException if form snapshot is missing required fieldId") {
-                val formSnapshot = FormSnapshot(
-                    formIdentifier = "kartlegging-test-form",
-                    formSemanticVersion = "1.0.0",
-                    formSnapshotVersion = "1",
-                    fieldSnapshots = listOf(
-                        RadioGroupFieldSnapshot(
-                            fieldId = "hvorSannsynligTilbakeTilJobben",
-                            label = "Label 1",
-                            options = listOf(
-                                FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
-                                FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
-                            ),
-                        ),
-                        RadioGroupFieldSnapshot(
-                            fieldId = "samarbeidOgRelasjonTilArbeidsgiver",
-                            label = "Label 2",
-                            options = listOf(
-                                FormSnapshotFieldOption("opt1", "Option 1", wasSelected = true),
-                                FormSnapshotFieldOption("opt2", "Option 2", wasSelected = false),
-                            ),
-                        ),
-                        // Missing required naarTilbakeTilJobben
-                    ),
-                )
-                val request = KartleggingssporsmalRequest(formSnapshot = formSnapshot)
-
-                shouldThrow<InvalidFormException> {
-                    controller.postKartleggingssporsmal(request)
-                }
-            }
-
             it(
                 "returns 400 InvalidFormException if form contains required RadioGroupFieldSnapshot with no option selected"
             ) {
@@ -198,5 +165,6 @@ class KartleggingssporsmalControllerV1Test :
                     controller.postKartleggingssporsmal(request)
                 }
             }
+
         }
     })


### PR DESCRIPTION
<!-- Managed by esyfo-cli. Do not edit manually. Changes will be overwritten.
     For repo-specific customizations, create your own files without this header. -->
## Beskrivelse

Fjerner validering av requiredFieldIds. Kan diskuteres om vi ønsker å gjøre dette, men tenker det kan bli mye å vedlikeholde nå som vi skal støtte flere skjemavarianter. Denne valideringen skjer på en måte også i backenden til bro-frontend.
Hva tenker dere?


## Endringer

<!-- - `fil/modul`: Hva som ble endret -->

## Issue

<!-- Closes #NUMMER / Relates to #NUMMER -->

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil
- [ ] Endringene er testet (manuelt eller automatisk)
- [ ] Ingen sensitiv data eksponert (tokens, credentials, PII)
