### PR TITLE
fix(mikrofrontend): allow meroppfolging-microfrontend access

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -71,7 +71,7 @@ spec:
         - application: meroppfolging-frontend
         - application: bro-frontend
         - application: esyfo-proxy
-        - application: esyfo-microfrontends
+        - application: meroppfolging-microfrontend
         - application: syfomodiaperson
           namespace: teamsykefravr
         - application: tokenx-token-generator
@@ -92,6 +92,8 @@ spec:
   env:
     - name: MEROPPFOLGING_FRONTEND_CLIENT_ID
       value: "dev-gcp:team-esyfo:meroppfolging-frontend"
+    - name: MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID
+      value: "dev-gcp:team-esyfo:meroppfolging-microfrontend"
     - name: BRO_FRONTEND_CLIENT_ID
       value: "dev-gcp:team-esyfo:bro-frontend"
     - name: TOKEN_X_GENERATOR_CLIENT_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -71,7 +71,7 @@ spec:
         - application: meroppfolging-frontend
         - application: bro-frontend
         - application: esyfo-proxy
-        - application: esyfo-microfrontends
+        - application: meroppfolging-microfrontend
         - application: syfomodiaperson
           namespace: teamsykefravr
     outbound:
@@ -90,6 +90,8 @@ spec:
   env:
     - name: MEROPPFOLGING_FRONTEND_CLIENT_ID
       value: "prod-gcp:team-esyfo:meroppfolging-frontend"
+    - name: MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID
+      value: "prod-gcp:team-esyfo:meroppfolging-microfrontend"
     - name: BRO_FRONTEND_CLIENT_ID
       value: "prod-gcp:team-esyfo:bro-frontend"
     - name: ESYFO_PROXY_CLIENT_ID

--- a/src/main/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendController.kt
+++ b/src/main/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendController.kt
@@ -20,6 +20,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/mikrofrontend/v1")
 @ProtectedWithClaims(issuer = "tokenx", combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])
 class MikrofrontendController(
+    @param:Value("\${MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID}")
+    private val meroppfolgingMicrofrontendClientId: String,
     @param:Value("\${ESYFO_PROXY_CLIENT_ID}")
     val esyfoProxyClientId: String,
     val tokenValidationContextHolder: TokenValidationContextHolder,
@@ -30,7 +32,7 @@ class MikrofrontendController(
     @PostConstruct
     fun init() {
         tokenValidator =
-            TokenValidator(tokenValidationContextHolder, listOf(esyfoProxyClientId))
+            TokenValidator(tokenValidationContextHolder, listOf(esyfoProxyClientId, meroppfolgingMicrofrontendClientId))
     }
 
     @GetMapping("/status", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/resources/application-docker.yaml
+++ b/src/main/resources/application-docker.yaml
@@ -50,6 +50,8 @@ kafka:
     password: credstore-password
 
 MEROPPFOLGING_FRONTEND_CLIENT_ID: 'meroppfolging-frontend-client-id'
+MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID: 'meroppfolging-microfrontend-client-id'
+
 BRO_FRONTEND_CLIENT_ID: 'bro-frontend'
 ESYFO_PROXY_CLIENT_ID: 'esyfo-proxy-client-id'
 SYFOOPPDFGEN_URL: 'http://syfooppdfgenurl'

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -8,6 +8,7 @@ no.nav.security.jwt:
       accepted_audience: meroppfolging-backend-client-id
 
 MEROPPFOLGING_FRONTEND_CLIENT_ID: 'meroppfolging-frontend-client-id'
+MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID: 'meroppfolging-microfrontend-client-id'
 BRO_FRONTEND_CLIENT_ID: 'bro-frontend-client-id'
 ESYFO_PROXY_CLIENT_ID: 'esyfo-proxy-client-id'
 SYFOOPPDFGEN_URL: 'http://syfooppdfgenurl'


### PR DESCRIPTION
## Beskrivelse

Gir `meroppfolging-microfrontend` tilgang til mikrofrontend-status ved å oppdatere både tokenvalidering og NAIS accessPolicy.

## Endringer

- `src/main/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendController.kt`: godtar `MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID` som gyldig klient i `TokenValidator`
- `nais/nais-dev.yaml`, `nais/nais-prod.yaml`: erstatter feil inbound appnavn og legger til miljøvariabel for client ID
- `src/main/resources/application-docker.yaml`, `src/test/resources/application.yaml`: legger til lokal- og testkonfig for `MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID`

## Issue

Ingen tilknyttet issue. Trengs for at `meroppfolging-microfrontend` skal kunne kalle `/api/mikrofrontend/v1/status`.

## Sjekkliste

- [ ] Koden kompilerer og linter uten feil (`./gradlew build` feiler for eksisterende ktlint-feil i tester, blant annet i `KandidatConsumerTest` og `KartleggingssporsmalControllerV1Test`)
- [ ] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)