### PR TITLE
fix(auth): remove esyfo-proxy client access

### DIFF
--- a/nais/nais-dev.yaml
+++ b/nais/nais-dev.yaml
@@ -70,7 +70,6 @@ spec:
       rules:
         - application: meroppfolging-frontend
         - application: bro-frontend
-        - application: esyfo-proxy
         - application: meroppfolging-microfrontend
         - application: syfomodiaperson
           namespace: teamsykefravr
@@ -98,8 +97,6 @@ spec:
       value: "dev-gcp:team-esyfo:bro-frontend"
     - name: TOKEN_X_GENERATOR_CLIENT_ID
       value: "dev-gcp:nais:tokenx-token-generator"
-    - name: ESYFO_PROXY_CLIENT_ID
-      value: "dev-gcp:team-esyfo:esyfo-proxy"
     - name: ISOPPFOLGINGSTILFELLE_URL
       value: http://isoppfolgingstilfelle.teamsykefravr
     - name: ISOPPFOLGINGSTILFELLE_ID

--- a/nais/nais-prod.yaml
+++ b/nais/nais-prod.yaml
@@ -70,7 +70,6 @@ spec:
       rules:
         - application: meroppfolging-frontend
         - application: bro-frontend
-        - application: esyfo-proxy
         - application: meroppfolging-microfrontend
         - application: syfomodiaperson
           namespace: teamsykefravr
@@ -94,8 +93,6 @@ spec:
       value: "prod-gcp:team-esyfo:meroppfolging-microfrontend"
     - name: BRO_FRONTEND_CLIENT_ID
       value: "prod-gcp:team-esyfo:bro-frontend"
-    - name: ESYFO_PROXY_CLIENT_ID
-      value: "prod-gcp:team-esyfo:esyfo-proxy"
     - name: ISOPPFOLGINGSTILFELLE_URL
       value: http://isoppfolgingstilfelle.teamsykefravr
     - name: ISOPPFOLGINGSTILFELLE_ID

--- a/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1.kt
@@ -8,7 +8,6 @@ import no.nav.syfo.auth.getFnr
 import no.nav.syfo.kartlegging.domain.KandidatStatusResponse
 import no.nav.syfo.kartlegging.domain.KartleggingssporsmalRequest
 import no.nav.syfo.kartlegging.domain.PersistedKartleggingssporsmal
-import no.nav.syfo.kartlegging.exception.KandidatNotFoundException
 import no.nav.syfo.kartlegging.exception.NotKandidatException
 import no.nav.syfo.kartlegging.service.KandidatService
 import no.nav.syfo.kartlegging.service.KartleggingssporsmalService

--- a/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
+++ b/src/main/kotlin/no/nav/syfo/kartlegging/service/KartleggingssporsmalService.kt
@@ -7,9 +7,7 @@ import no.nav.syfo.kartlegging.domain.Kartleggingssporsmal
 import no.nav.syfo.kartlegging.domain.KartleggingssporsmalKandidat
 import no.nav.syfo.kartlegging.domain.KartleggingssporsmalRequest
 import no.nav.syfo.kartlegging.domain.PersistedKartleggingssporsmal
-import no.nav.syfo.kartlegging.domain.formsnapshot.FieldSnapshot
 import no.nav.syfo.kartlegging.domain.formsnapshot.FormSnapshot
-import no.nav.syfo.kartlegging.domain.formsnapshot.FormSnapshotFieldType
 import no.nav.syfo.kartlegging.domain.formsnapshot.validateFields
 import no.nav.syfo.kartlegging.exception.InvalidFormException
 import no.nav.syfo.kartlegging.kafka.KartleggingssvarEvent

--- a/src/main/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendController.kt
+++ b/src/main/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendController.kt
@@ -22,8 +22,6 @@ import org.springframework.web.bind.annotation.RestController
 class MikrofrontendController(
     @param:Value("\${MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID}")
     private val meroppfolgingMicrofrontendClientId: String,
-    @param:Value("\${ESYFO_PROXY_CLIENT_ID}")
-    val esyfoProxyClientId: String,
     val tokenValidationContextHolder: TokenValidationContextHolder,
     val mikrofrontendService: MikrofrontendService,
 ) {
@@ -32,7 +30,7 @@ class MikrofrontendController(
     @PostConstruct
     fun init() {
         tokenValidator =
-            TokenValidator(tokenValidationContextHolder, listOf(esyfoProxyClientId, meroppfolgingMicrofrontendClientId))
+            TokenValidator(tokenValidationContextHolder, meroppfolgingMicrofrontendClientId)
     }
 
     @GetMapping("/status", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2.kt
+++ b/src/main/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2.kt
@@ -31,10 +31,8 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/api/v2/senoppfolging")
 @ProtectedWithClaims(issuer = "tokenx", combineWithOr = true, claimMap = ["acr=Level4", "acr=idporten-loa-high"])
 class SenOppfolgingControllerV2(
-    @Value("\${MEROPPFOLGING_FRONTEND_CLIENT_ID}")
+    @param:Value("\${MEROPPFOLGING_FRONTEND_CLIENT_ID}")
     val merOppfolgingFrontendClientId: String,
-    @Value("\${ESYFO_PROXY_CLIENT_ID}")
-    val esyfoProxyClientId: String,
     val tokenValidationContextHolder: TokenValidationContextHolder,
     val senOppfolgingService: SenOppfolgingService,
 ) {
@@ -43,8 +41,7 @@ class SenOppfolgingControllerV2(
 
     @PostConstruct
     fun init() {
-        tokenValidator =
-            TokenValidator(tokenValidationContextHolder, listOf(merOppfolgingFrontendClientId, esyfoProxyClientId))
+        tokenValidator = TokenValidator(tokenValidationContextHolder, merOppfolgingFrontendClientId)
     }
 
     @GetMapping("/status", produces = [MediaType.APPLICATION_JSON_VALUE])

--- a/src/main/resources/application-docker.yaml
+++ b/src/main/resources/application-docker.yaml
@@ -53,7 +53,6 @@ MEROPPFOLGING_FRONTEND_CLIENT_ID: 'meroppfolging-frontend-client-id'
 MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID: 'meroppfolging-microfrontend-client-id'
 
 BRO_FRONTEND_CLIENT_ID: 'bro-frontend'
-ESYFO_PROXY_CLIENT_ID: 'esyfo-proxy-client-id'
 SYFOOPPDFGEN_URL: 'http://syfooppdfgenurl'
 NAIS_CLUSTER_NAME: 'local'
 ELECTOR_GET_URL: 'http://elector-get-url'

--- a/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1Test.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/KartleggingssporsmalControllerV1Test.kt
@@ -165,6 +165,5 @@ class KartleggingssporsmalControllerV1Test :
                     controller.postKartleggingssporsmal(request)
                 }
             }
-
         }
     })

--- a/src/test/kotlin/no/nav/syfo/kartlegging/kafka/KandidatConsumerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/kartlegging/kafka/KandidatConsumerTest.kt
@@ -20,22 +20,22 @@ import tools.jackson.module.kotlin.jsonMapper
 import java.time.OffsetDateTime
 import java.util.UUID
 
-class KandidatConsumerTest : DescribeSpec({
-    val kandidatService = mockk<KandidatService>()
-    val metric = mockk<Metric>()
-    val ack = mockk<Acknowledgment>()
-    val consumer = KandidatConsumer(kandidatService, metric)
-    val objectMapper = jsonMapper {}
+class KandidatConsumerTest :
+    DescribeSpec({
+        val kandidatService = mockk<KandidatService>()
+        val metric = mockk<Metric>()
+        val ack = mockk<Acknowledgment>()
+        val consumer = KandidatConsumer(kandidatService, metric)
+        val objectMapper = jsonMapper {}
 
-    beforeTest {
-        clearAllMocks()
-        every { kandidatService.persistKandidater(any()) } just runs
-        every { metric.countKartleggingssporsmalKandidatReceived(any()) } just runs
-        every { ack.acknowledge() } just runs
-    }
+        beforeTest {
+            clearAllMocks()
+            every { kandidatService.persistKandidater(any()) } just runs
+            every { metric.countKartleggingssporsmalKandidatReceived(any()) } just runs
+            every { ack.acknowledge() } just runs
+        }
 
-    fun createRecord(event: KandidatKafkaEvent): ConsumerRecord<String, String?> =
-        ConsumerRecord(
+        fun createRecord(event: KandidatKafkaEvent): ConsumerRecord<String, String?> = ConsumerRecord(
             KandidatConsumer.KANDIDAT_TOPIC,
             0,
             0L,
@@ -43,113 +43,110 @@ class KandidatConsumerTest : DescribeSpec({
             objectMapper.writeValueAsString(event),
         )
 
-    fun createEvent(
-        status: String = "KANDIDAT",
-        skjemavariant: String? = null,
-    ) = KandidatKafkaEvent(
-        personident = "12345678910",
-        kandidatUuid = UUID.randomUUID(),
-        status = status,
-        skjemavariant = skjemavariant,
-        createdAt = OffsetDateTime.now(),
-    )
+        fun createEvent(status: String = "KANDIDAT", skjemavariant: String? = null,) = KandidatKafkaEvent(
+            personident = "12345678910",
+            kandidatUuid = UUID.randomUUID(),
+            status = status,
+            skjemavariant = skjemavariant,
+            createdAt = OffsetDateTime.now(),
+        )
 
-    describe("listen") {
-        it("should persist kandidat with status KANDIDAT and acknowledge") {
-            val event = createEvent(status = "KANDIDAT", skjemavariant = "FLERVALG_FRITEKST_V1")
-            val records = listOf(createRecord(event))
+        describe("listen") {
+            it("should persist kandidat with status KANDIDAT and acknowledge") {
+                val event = createEvent(status = "KANDIDAT", skjemavariant = "FLERVALG_FRITEKST_V1")
+                val records = listOf(createRecord(event))
 
-            consumer.listen(records, ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.size shouldBe 1
-            persisted.captured.first().personIdent shouldBe event.personident
-            persisted.captured.first().kandidatId shouldBe event.kandidatUuid
-            persisted.captured.first().status shouldBe KandidatStatus.KANDIDAT
-            persisted.captured.first().skjemavariant shouldBe "FLERVALG_FRITEKST_V1"
-            verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(1.0) }
-            verify(exactly = 1) { ack.acknowledge() }
-        }
-
-        it("should filter out kandidat with status IKKE_KANDIDAT") {
-            val event = createEvent(status = "IKKE_KANDIDAT")
-            val records = listOf(createRecord(event))
-
-            consumer.listen(records, ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.size shouldBe 0
-            verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(0.0) }
-            verify(exactly = 1) { ack.acknowledge() }
-        }
-
-        it("should discard event with unknown status") {
-            val event = createEvent(status = "UNKNOWN_STATUS")
-            val records = listOf(createRecord(event))
-
-            consumer.listen(records, ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.size shouldBe 0
-            verify(exactly = 1) { ack.acknowledge() }
-        }
-
-        it("should default skjemavariant to FLERVALG_V1 when null") {
-            val event = createEvent(status = "KANDIDAT", skjemavariant = null)
-            val records = listOf(createRecord(event))
-
-            consumer.listen(records, ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.first().skjemavariant shouldBe "FLERVALG_V1"
-        }
-
-        it("should skip tombstone records (null value)") {
-            val record = ConsumerRecord<String, String?>(
-                KandidatConsumer.KANDIDAT_TOPIC,
-                0,
-                0L,
-                "some-key",
-                null,
-            )
-
-            consumer.listen(listOf(record), ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.size shouldBe 0
-            verify(exactly = 1) { ack.acknowledge() }
-        }
-
-        it("should process multiple records and filter correctly") {
-            val kandidat = createEvent(status = "KANDIDAT", skjemavariant = "FLERVALG_V1")
-            val ikkeKandidat = createEvent(status = "IKKE_KANDIDAT")
-            val unknown = createEvent(status = "BOGUS")
-            val records = listOf(createRecord(kandidat), createRecord(ikkeKandidat), createRecord(unknown))
-
-            consumer.listen(records, ack)
-
-            val persisted = slot<List<KartleggingssporsmalKandidat>>()
-            verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
-            persisted.captured.size shouldBe 1
-            persisted.captured.first().kandidatId shouldBe kandidat.kandidatUuid
-            verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(1.0) }
-        }
-
-        it("should rethrow exception and not acknowledge on failure") {
-            val event = createEvent(status = "KANDIDAT")
-            val records = listOf(createRecord(event))
-            every { kandidatService.persistKandidater(any()) } throws RuntimeException("DB error")
-
-            shouldThrow<RuntimeException> {
                 consumer.listen(records, ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.size shouldBe 1
+                persisted.captured.first().personIdent shouldBe event.personident
+                persisted.captured.first().kandidatId shouldBe event.kandidatUuid
+                persisted.captured.first().status shouldBe KandidatStatus.KANDIDAT
+                persisted.captured.first().skjemavariant shouldBe "FLERVALG_FRITEKST_V1"
+                verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(1.0) }
+                verify(exactly = 1) { ack.acknowledge() }
             }
 
-            verify(exactly = 0) { ack.acknowledge() }
+            it("should filter out kandidat with status IKKE_KANDIDAT") {
+                val event = createEvent(status = "IKKE_KANDIDAT")
+                val records = listOf(createRecord(event))
+
+                consumer.listen(records, ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.size shouldBe 0
+                verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(0.0) }
+                verify(exactly = 1) { ack.acknowledge() }
+            }
+
+            it("should discard event with unknown status") {
+                val event = createEvent(status = "UNKNOWN_STATUS")
+                val records = listOf(createRecord(event))
+
+                consumer.listen(records, ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.size shouldBe 0
+                verify(exactly = 1) { ack.acknowledge() }
+            }
+
+            it("should default skjemavariant to FLERVALG_V1 when null") {
+                val event = createEvent(status = "KANDIDAT", skjemavariant = null)
+                val records = listOf(createRecord(event))
+
+                consumer.listen(records, ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.first().skjemavariant shouldBe "FLERVALG_V1"
+            }
+
+            it("should skip tombstone records (null value)") {
+                val record = ConsumerRecord<String, String?>(
+                    KandidatConsumer.KANDIDAT_TOPIC,
+                    0,
+                    0L,
+                    "some-key",
+                    null,
+                )
+
+                consumer.listen(listOf(record), ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.size shouldBe 0
+                verify(exactly = 1) { ack.acknowledge() }
+            }
+
+            it("should process multiple records and filter correctly") {
+                val kandidat = createEvent(status = "KANDIDAT", skjemavariant = "FLERVALG_V1")
+                val ikkeKandidat = createEvent(status = "IKKE_KANDIDAT")
+                val unknown = createEvent(status = "BOGUS")
+                val records = listOf(createRecord(kandidat), createRecord(ikkeKandidat), createRecord(unknown))
+
+                consumer.listen(records, ack)
+
+                val persisted = slot<List<KartleggingssporsmalKandidat>>()
+                verify(exactly = 1) { kandidatService.persistKandidater(capture(persisted)) }
+                persisted.captured.size shouldBe 1
+                persisted.captured.first().kandidatId shouldBe kandidat.kandidatUuid
+                verify(exactly = 1) { metric.countKartleggingssporsmalKandidatReceived(1.0) }
+            }
+
+            it("should rethrow exception and not acknowledge on failure") {
+                val event = createEvent(status = "KANDIDAT")
+                val records = listOf(createRecord(event))
+                every { kandidatService.persistKandidater(any()) } throws RuntimeException("DB error")
+
+                shouldThrow<RuntimeException> {
+                    consumer.listen(records, ack)
+                }
+
+                verify(exactly = 0) { ack.acknowledge() }
+            }
         }
-    }
-})
+    })

--- a/src/test/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendControllerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/mikrofrontend/MikrofrontendControllerTest.kt
@@ -1,0 +1,84 @@
+package no.nav.syfo.mikrofrontend
+
+import com.nimbusds.jwt.JWTClaimsSet
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import no.nav.security.token.support.core.context.TokenValidationContext
+import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.syfo.auth.NoAccess
+import no.nav.syfo.mikrofrontend.domain.MerOppfolgingStatusDTO
+import no.nav.syfo.mikrofrontend.service.MikrofrontendService
+import no.nav.syfo.senoppfolging.v2.domain.ResponseStatus.NO_RESPONSE
+import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingStatusDTOV2
+
+class MikrofrontendControllerTest :
+    DescribeSpec({
+        val tokenValidationContextHolder = mockk<TokenValidationContextHolder>(relaxed = true)
+        val mikrofrontendService = mockk<MikrofrontendService>(relaxed = true)
+
+        val fnr = "12345678910"
+
+        fun tokenValidationContext(clientId: String): TokenValidationContext {
+            val claims =
+                JWTClaimsSet.Builder()
+                    .claim("client_id", clientId)
+                    .claim("pid", fnr)
+                    .build()
+            val jwtToken = mockk<JwtToken>()
+            every { jwtToken.jwtTokenClaims } returns no.nav.security.token.support.core.jwt.JwtTokenClaims(claims)
+            every { jwtToken.encodedToken } returns "token"
+            return TokenValidationContext(mapOf("tokenx" to jwtToken))
+        }
+
+        beforeTest {
+            clearAllMocks()
+        }
+
+        describe("Auth") {
+            it("accepts meroppfolging mikrofrontend client id") {
+                val controller =
+                    MikrofrontendController(
+                        meroppfolgingMicrofrontendClientId = "meroppfolgingMicrofrontendClientId",
+                        tokenValidationContextHolder = tokenValidationContextHolder,
+                        mikrofrontendService = mikrofrontendService,
+                    ).apply {
+                        init()
+                    }
+                every { tokenValidationContextHolder.getTokenValidationContext() } returns
+                    tokenValidationContext("meroppfolgingMicrofrontendClientId")
+                every { mikrofrontendService.status(fnr, "token") } returns
+                    MerOppfolgingStatusDTO.IngenOppfolging(
+                        senOppfolgingStatus = SenOppfolgingStatusDTOV2(NO_RESPONSE, null, null, null, null, null, true)
+                    )
+
+                val status = controller.status()
+
+                status shouldBe
+                    MerOppfolgingStatusDTO.IngenOppfolging(
+                        senOppfolgingStatus = SenOppfolgingStatusDTOV2(NO_RESPONSE, null, null, null, null, null, true)
+                    )
+            }
+
+            it("rejects unauthorized client id") {
+                val controller =
+                    MikrofrontendController(
+                        meroppfolgingMicrofrontendClientId = "meroppfolgingMicrofrontendClientId",
+                        tokenValidationContextHolder = tokenValidationContextHolder,
+                        mikrofrontendService = mikrofrontendService,
+                    ).apply {
+                        init()
+                    }
+                every { tokenValidationContextHolder.getTokenValidationContext() } returns
+                    tokenValidationContext("unauthorizedClientId")
+
+                shouldThrow<NoAccess> {
+                    controller.status()
+                }
+            }
+        }
+    })

--- a/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
+++ b/src/test/kotlin/no/nav/syfo/senoppfolging/v2/SenOppfolgingControllerV2Test.kt
@@ -1,5 +1,6 @@
 package no.nav.syfo.senoppfolging.v2
 
+import com.nimbusds.jwt.JWTClaimsSet
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
@@ -8,7 +9,10 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import junit.framework.TestCase.assertTrue
+import no.nav.security.token.support.core.context.TokenValidationContext
 import no.nav.security.token.support.core.context.TokenValidationContextHolder
+import no.nav.security.token.support.core.jwt.JwtToken
+import no.nav.syfo.auth.NoAccess
 import no.nav.syfo.auth.TokenValidator
 import no.nav.syfo.auth.getFnr
 import no.nav.syfo.besvarelse.database.ResponseDao
@@ -34,6 +38,7 @@ import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingDTOV2
 import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingQuestionTypeV2.BEHOV_FOR_OPPFOLGING
 import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingQuestionTypeV2.FREMTIDIG_SITUASJON
 import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingQuestionV2
+import no.nav.syfo.senoppfolging.v2.domain.SenOppfolgingStatusDTOV2
 import no.nav.syfo.senoppfolging.v2.domain.toQuestionResponse
 import no.nav.syfo.syfoopppdfgen.PdfgenService
 import no.nav.syfo.sykepengedagerinformasjon.service.SykepengedagerInformasjonService
@@ -73,7 +78,6 @@ class SenOppfolgingControllerV2Test :
             val controller =
                 SenOppfolgingControllerV2(
                     merOppfolgingFrontendClientId = "merOppfolgingFrontendClientId",
-                    esyfoProxyClientId = "esyfoProxyClientId",
                     tokenValidationContextHolder = tokenValidationContextHolder,
                     senOppfolgingService = senOppfolgingService,
                 ).apply {
@@ -106,6 +110,18 @@ class SenOppfolgingControllerV2Test :
 
             val varselUuid = UUID.randomUUID()
             val varselSentAt = LocalDateTime.now().minusDays(20)
+
+            fun tokenValidationContext(clientId: String): TokenValidationContext {
+                val claims =
+                    JWTClaimsSet.Builder()
+                        .claim("client_id", clientId)
+                        .claim("pid", ansattFnr)
+                        .build()
+                val jwtToken = mockk<JwtToken>()
+                every { jwtToken.jwtTokenClaims } returns no.nav.security.token.support.core.jwt.JwtTokenClaims(claims)
+                every { jwtToken.encodedToken } returns "token"
+                return TokenValidationContext(mapOf("tokenx" to jwtToken))
+            }
 
             beforeTest {
                 clearAllMocks()
@@ -239,6 +255,59 @@ class SenOppfolgingControllerV2Test :
                         verify(
                             exactly = 1,
                         ) { dokarkivClient.postDocumentsForsendelseToDokarkiv(ansattFnr, any(), any(), any(), any()) }
+                    }
+                }
+            }
+
+            describe("Auth") {
+                it("accepts meroppfolging frontend client id") {
+                    val authSenOppfolgingService = mockk<SenOppfolgingService>()
+                    val expectedStatus =
+                        SenOppfolgingStatusDTOV2(
+                            NO_RESPONSE,
+                            null,
+                            null,
+                            null,
+                            null,
+                            null,
+                            true,
+                        )
+                    val authAwareController =
+                        SenOppfolgingControllerV2(
+                            merOppfolgingFrontendClientId = "merOppfolgingFrontendClientId",
+                            tokenValidationContextHolder = tokenValidationContextHolder,
+                            senOppfolgingService = authSenOppfolgingService,
+                        ).apply {
+                            init()
+                        }
+                    every { tokenValidationContextHolder.getTokenValidationContext() } returns
+                        tokenValidationContext("merOppfolgingFrontendClientId")
+                    every {
+                        authSenOppfolgingService.prepareAndBuildSenOppfolgingStatusDTOV2(ansattFnr, "token")
+                    } returns expectedStatus
+
+                    val status = authAwareController.status()
+
+                    status shouldBe expectedStatus
+                    verify(exactly = 1) {
+                        authSenOppfolgingService.prepareAndBuildSenOppfolgingStatusDTOV2(ansattFnr, "token")
+                    }
+                }
+
+                it("rejects unauthorized client id") {
+                    val authAwareController =
+                        SenOppfolgingControllerV2(
+                            merOppfolgingFrontendClientId = "merOppfolgingFrontendClientId",
+                            tokenValidationContextHolder = tokenValidationContextHolder,
+                            senOppfolgingService = senOppfolgingService,
+                        ).apply {
+                            init()
+                        }
+                    every { tokenValidationContextHolder.getTokenValidationContext() } returns
+                        tokenValidationContext("unauthorizedClientId")
+
+                    shouldThrow<NoAccess> {
+                        authAwareController.status()
                     }
                 }
             }

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -10,7 +10,6 @@ no.nav.security.jwt:
 MEROPPFOLGING_FRONTEND_CLIENT_ID: 'meroppfolging-frontend-client-id'
 MEROPPFOLGING_MICRO_FRONTEND_CLIENT_ID: 'meroppfolging-microfrontend-client-id'
 BRO_FRONTEND_CLIENT_ID: 'bro-frontend-client-id'
-ESYFO_PROXY_CLIENT_ID: 'esyfo-proxy-client-id'
 SYFOOPPDFGEN_URL: 'http://syfooppdfgenurl'
 NAIS_CLUSTER_NAME: 'local'
 ELECTOR_GET_URL: 'http://elector-get-url'


### PR DESCRIPTION
## Beskrivelse

Fjerner esyfo-proxy som tillatt klient i meroppfolging-backend. Dette rydder bort proxy-avhengigheten fra manifest, konfigurasjon og TokenX-validering, og sikrer at repoet ikke lenger har referanser til esyfo-proxy.

## Endringer

- `nais/nais-dev.yaml`, `nais/nais-prod.yaml`: fjernet inbound-regel og client-id for esyfo-proxy
- `MikrofrontendController` og `SenOppfolgingControllerV2`: fjernet esyfo-proxy fra tillatte TokenX-klienter
- `application-docker.yaml` og `src/test/resources/application.yaml`: fjernet `ESYFO_PROXY_CLIENT_ID`
- `SenOppfolgingControllerV2Test` og ny `MikrofrontendControllerTest`: la til auth-tester for tillatt og uautorisert klient uten esyfo-proxy-referanser

## Issue

Closes #374

## Sjekkliste

- [x] Koden kompilerer og linter uten feil
- [x] Endringene er testet (manuelt eller automatisk)
- [x] Ingen sensitiv data eksponert (tokens, credentials, PII)